### PR TITLE
Rename package name to tongsuo-openjdk-dynamic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,17 +185,29 @@ jobs:
           add_path("$ENV{RUNNER_TEMP}\\tongsuo\\bin");
           add_path("$ENV{RUNNER_TEMP}\\tongsuo\\lib");
 
-      - name: Build with Gradle based on Tongsuo dynamic library
+      - name: Build with Gradle
         shell: bash
         run: ./gradlew assemble -PcheckErrorQueue -PtongsuoDynamic=1
 
-      - name: Test with Gradle based on Tongsuo dynamic library
+      - name: Test with Gradle on Windows or macOS
+        if: runner.os == 'Windows' || runner.os =='macOS'
         shell: bash
         run: ./gradlew test -PcheckErrorQueue -PtongsuoDynamic=1
 
-      - name: Other checks with Gradle based on Tongsuo dynamic library
+      - name: Test with Gradle on Linux
+        if: runner.os == 'Linux'
+        shell: bash
+        run: LD_LIBRARY_PATH=$TONGSUO_HOME/lib:$LD_LIBRARY_PATH ./gradlew test -PcheckErrorQueue -PtongsuoDynamic=1
+
+      - name: Other checks with Gradle on Windows or macOS
+        if: runner.os == 'Windows' || runner.os =='macOS'
         shell: bash
         run: ./gradlew check -PcheckErrorQueue -PtongsuoDynamic=1
+
+      - name: Other checks with Gradle on Linux
+        if: runner.os == 'Linux'
+        shell: bash
+        run: LD_LIBRARY_PATH=$TONGSUO_HOME/lib:$LD_LIBRARY_PATH ./gradlew check -PcheckErrorQueue -PtongsuoDynamic=1
 
       - name: Build test JAR with dependencies based on Tongsuo dynamic library
         if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           pushd ${{ github.workspace }}/Tongsuo
           perl ./config --banner=Configured ${{ matrix.platform.target }} --prefix=$TONGSUO_HOME --libdir=$TONGSUO_HOME/lib enable-weak-ssl-ciphers enable-ntls no-shared \
-                --strict-warnings --release
+                --strict-warnings --release -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong
           make -s -j4
           make install
           popd
@@ -122,6 +122,7 @@ jobs:
           tag_name: ${{ github.event.inputs.version }}
           draft: true
           prerelease: true
+          fail_on_unmatched_files: true
           files: openjdk/build/libs/tongsuo-openjdk-${{ github.event.inputs.version }}-*.jar
 
   build-with-tongsuo-dynamic:
@@ -161,6 +162,12 @@ jobs:
         run: |
           echo "TONGSUO_HOME=${{ runner.temp }}/tongsuo" >> $GITHUB_ENV
 
+      - name: Set runner-specific environment variables for macOS
+        shell: bash
+        if: runner.os == 'macOS'
+        run: |
+          echo "TONGSUO_HOME=/opt/tongsuo" >> $GITHUB_ENV
+
       - uses: actions/checkout@v4
 
       - name: Fetch Tongsuo source
@@ -175,7 +182,7 @@ jobs:
           perl ./config --banner=Configured ${{ matrix.platform.target }} --prefix=$TONGSUO_HOME --libdir=$TONGSUO_HOME/lib enable-weak-ssl-ciphers enable-ntls \
                 --strict-warnings --release
           make -s -j4
-          make install
+          sudo make install
           popd
 
       - uses: ilammy/msvc-dev-cmd@v1
@@ -225,19 +232,33 @@ jobs:
         run: |
           ./gradlew assemble -PcheckErrorQueue -PtongsuoDynamic=1
 
-      - name: Test with Gradle
+      - name: Test with Gradle on Windows or macOS
+        if: runner.os == 'Windows' || runner.os == 'macOS'
         shell: bash
         run: ./gradlew test -PcheckErrorQueue -PtongsuoDynamic=1
 
-      - name: Other checks with Gradle
+      - name: Test with Gradle on Linux
+        if: runner.os == 'Linux'
+        shell: bash
+        run: LD_LIBRARY_PATH=$TONGSUO_HOME/lib:$LD_LIBRARY_PATH ./gradlew test -PcheckErrorQueue -PtongsuoDynamic=1
+
+      - name: Other checks with Gradle on Windows or macOS
+        if: runner.os == 'Windows' || runner.os =='macOS'
         shell: bash
         run: ./gradlew check -PcheckErrorQueue -PtongsuoDynamic=1
+
+      - name: Other checks with Gradle on Linux
+        if: runner.os == 'Linux'
+        shell: bash
+        run: LD_LIBRARY_PATH=$TONGSUO_HOME/lib:$LD_LIBRARY_PATH ./gradlew check -PcheckErrorQueue -PtongsuoDynamic=1
 
       - name: Rename to dynamic jar
         shell: bash
         run: |
-          for file in openjdk/build/libs/tongsuo-openjdk-${{ github.event.inputs.version }}-*.jar; do
-            mv "$file" "${file%.*}-dynamic.jar"
+          cd openjdk/build/libs/
+          for file in tongsuo-openjdk-${{ github.event.inputs.version }}-*.jar; do
+            os_arch_jar=$(echo "$file" | cut -d'-' -f4-)
+            mv "$file" "tongsuo-openjdk-dynamic-${{ github.event.inputs.version }}-${os_arch_jar}"
           done
 
       - name: Release
@@ -247,4 +268,5 @@ jobs:
           tag_name: ${{ github.event.inputs.version }}
           draft: true
           prerelease: true
-          files: openjdk/build/libs/tongsuo-openjdk-${{ github.event.inputs.version }}-*-dynamic.jar
+          fail_on_unmatched_files: true
+          files: openjdk/build/libs/tongsuo-openjdk-dynamic-${{ github.event.inputs.version }}-*.jar

--- a/examples/jce/README.md
+++ b/examples/jce/README.md
@@ -7,9 +7,13 @@ Take TLS13Client and TLS13Server as an example.
 ## TLS13Client
 
 ```shell
-javac -cp openjdk/build/libs/tongsuo-openjdk-<version>-<os>-<arch>.jar examples/jce/TLS13Client.java
+cd examples/jce
 
-java -cp examples/jce:openjdk/build/libs/tongsuo-openjdk-<version>-<os>-<arch>.jar TLS13Client
+# build
+javac -cp /path/to/tongsuo-openjdk-<version>-<os>-<arch>.jar TLS13Client.java
+
+# run
+java -cp .:/path/to/tongsuo-openjdk-<version>-<os>-<arch>.jar TLS13Client
 ```
 
 ## TLS13Server
@@ -21,7 +25,9 @@ Note: sm2.crt, sm2.key and chain.crt are required to run the server.
 ```shell
 cd examples/jce
 
-javac -cp ~/.m2/repository/org/bouncycastle/bcprov-jdk15on/1.69/bcprov-jdk15on-1.69.jar:../../openjdk/build/libs/tongsuo-openjdk-<version>-<os>-<arch>.jar  TLS13Server.java
+# build
+javac -cp /path/to/bcprov-jdk15on-1.69.jar:/path/to/tongsuo-openjdk-<version>-<os>-<arch>.jar  TLS13Server.java
 
-java -cp .:/path/to/user/.m2/repository/org/bouncycastle/bcprov-jdk15on/1.69/bcprov-jdk15on-1.69.jar:../../openjdk/build/libs/tongsuo-openjdk-<version>-<os>-<arch>.jar TLS13Server
+# run
+java -cp .:/path/to/bcprov-jdk15on-1.69.jar:/path/to/tongsuo-openjdk-<version>-<os>-<arch>.jar TLS13Server
 ```

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -418,12 +418,6 @@ model {
                             linker.args "-L" + libPath,
                                     "-lssl",
                                     "-lcrypto"
-
-                            if (toolChain in Gcc) {
-                                linker.args "-Wl,-rpath=" + libPath
-                            } else if (toolChain in Clang) {
-                                linker.args "-Wl,-rpath," + libPath
-                            }
                         } else {
                             linker.args  libPath + "/libssl.a",
                                     libPath + "/libcrypto.a"


### PR DESCRIPTION
Rename package name to tongsuo-openjdk-dynamic when building with Tongsuo dynamic lib.

Add security compilation options when build Tongsuo.

Remove rpath.