### PR TITLE
Add SM3/SM Engine Example and Optimization the Sign performance

### DIFF
--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -220,6 +220,10 @@ public final class NativeCrypto {
 
     static native long EVP_MD_CTX_create();
 
+    static native long EVP_MD_CTX_create_with_pkey(NativeRef.EVP_PKEY key);
+
+    static native void EVP_MD_CTX_reset_with_pctx(NativeRef.EVP_MD_CTX ctx, long pctx);
+
     static native void EVP_MD_CTX_cleanup(NativeRef.EVP_MD_CTX ctx);
 
     static native void EVP_MD_CTX_destroy(long ctx);

--- a/examples/jce/SM2WithEngine.java
+++ b/examples/jce/SM2WithEngine.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 The Tongsuo Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://github.com/Tongsuo-Project/Tongsuo/blob/master/LICENSE.txt
+ */
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Security;
+import java.security.Signature;
+import net.tongsuo.TongsuoProvider;
+
+public class SM2WithEngine {
+    static {
+        // install tongsuo provider
+        TongsuoProvider ts = new TongsuoProvider();
+        if (ts.setEngine("hct") != 1) {
+            System.out.println("set engine failed");
+        }
+        Security.addProvider(ts);
+    }
+
+    public static void main(String[] args) throws Exception {
+        byte[] mess = "example".getBytes();
+
+        // SM3withSM2 requires SM2 key
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("SM2", "Tongsuo_Security_Provider");
+        KeyPair kp = kpg.generateKeyPair();
+        PrivateKey privateKey = kp.getPrivate();
+        PublicKey publicKey = kp.getPublic();
+
+        Signature sig = Signature.getInstance("SM3withSM2", "Tongsuo_Security_Provider");
+        // sign using private key
+        sig.initSign(privateKey);
+        // feed in mess(s)
+        sig.update(mess);
+        // genereate signatrue
+        byte[] signature = sig.sign();
+
+        // verify using public key
+        sig.initVerify(publicKey);
+        // same mess(s) as in signing procedure
+        sig.update(mess);
+        // return true if signature is genuine
+        System.out.println(sig.verify(signature));
+    }
+}

--- a/examples/jce/SM4WithEngine.java
+++ b/examples/jce/SM4WithEngine.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 The Tongsuo Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://github.com/Tongsuo-Project/Tongsuo/blob/master/LICENSE.txt
+ */
+
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.AlgorithmParameters;
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Base64;
+import net.tongsuo.TongsuoProvider;
+
+public class SM4WithEngine {
+    public static void main(String[] args) throws Exception {
+        TongsuoProvider ts = new TongsuoProvider();
+        if (ts.setEngine("hct") != 1) {
+            System.out.println("set engine failed");
+            return;
+        }
+        Security.addProvider(ts);
+
+        byte[] msg = "Hello SM4-CBC!".getBytes();
+        SecureRandom random = new SecureRandom();
+        int testLen = 32;
+        if(args.length > 0)
+        {
+           try{
+               testLen = Integer.parseInt(args[0]);
+               testLen = (testLen + 15) / 16 * 16;
+           } catch (NumberFormatException e)
+           {
+               System.out.println("Invalid input length");
+           }
+        }
+        // input padding
+        System.out.println("Test SM4 data length: " + testLen);
+        byte[] mess = new byte[testLen];
+        random.nextBytes(mess);
+        System.arraycopy(msg, 0, mess, 0, Math.min(msg.length, 16));
+
+        // algorithm/mode/padding
+        Cipher cipher = Cipher.getInstance("SM4/CBC/NoPadding", "Tongsuo_Security_Provider");
+        byte[] key = new byte[16];
+        random.nextBytes(key);
+        byte[] iv = new byte[16];
+        random.nextBytes(iv);
+        SecretKeySpec secretKey =  new SecretKeySpec(key, "SM4");
+        // Initialize the IV
+        AlgorithmParameters params = AlgorithmParameters.getInstance("SM4");
+        params.init(iv, "RAW");
+        // init cipher in encryption mode
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey, params);
+
+        byte[] ciphertext = cipher.doFinal(mess);
+
+        // init cipher in decryption mode
+        cipher.init(Cipher.DECRYPT_MODE, secretKey, params);
+        byte[] decrypted = cipher.doFinal(ciphertext);
+
+        // decrypted text should be identical to input
+        System.out.println(Base64.getEncoder().encodeToString(mess));
+        System.out.println(Base64.getEncoder().encodeToString(decrypted));
+    }
+}


### PR DESCRIPTION
1. Add OpenSSLSignature support reuse pctx and mdctx instead create every time
2. remove unnecessary 'resetContext' after engineSign or engineVerify in OpenSSLSignature.java 
3. add SM3 SM4 Engine examples